### PR TITLE
add meta to help find github repository

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,4 +34,14 @@ WriteMakefile
    'DEFINE'             => '',          # e.g., '-DHAVE_SOMETHING'
    'INC'                => '',          # e.g., '-I/usr/include/other'
    'SIGN'               => 1,
+   'META_MERGE'         => {
+                            'meta-spec' => { version => 2 },
+                            resources => {
+                              repository => {
+                                type => 'git',
+                                url  => 'https://github.com/pjacklam/p5-Math-BigInt-GMP.git',
+                                web  => 'https://github.com/pjacklam/p5-Math-BigInt-GMP',
+                              },
+                            },
+                           },
   );


### PR DESCRIPTION
This should make it easier to find this repository from metacpan.

based on https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions